### PR TITLE
Extend tile object/layer features

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ To find a layer (which itself is a nested display group), use map:findLayer().
 myLayer = map:findLayer( "hud" )
 myLayer.alpha = 0.5
 ```
+#### map:getFirstTile( property [, value ] )
+This funtion will return the *first* tile-based display object with the specified property in the map. Great for getting to the display object of a unique tile in the map. Optionally, you can specify a value for the property. If the value is omitted, the function will return the first tile that has the specified property regardless of the value of the property.
+``` 
+finishTile = map:getFirstTile( "type", "finish" )
+transition.blink( finishTile, { time=1000 } )
+```
+#### map:getAllTiles( property [, value ] )
+Same functionality as with `map:getFirstTile( property [, value ] )` (see above), but this function will return a list of all tile-based display objects in the map with the specified property.
+```
+enemies = map:getAllTiles( "isEnemy" )
+for i = 1, #enemies do
+  print( "enemy #" .. i .. " = " .. tostring( enemies[i] ) )
+end
+```
+
+
+
+
 ### Extensions
 
 #### map:extend(types)

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 In about 675 lines of code, **ponytiled** loads a sub-set of Tiled layers, tilesets and image collections. Built in plugin hooks and extensions make it easy to add support for many custom object types.
 
 - [x] Loads .LUA + .JSON exports from www.mapeditor.org
-- [x] Adds basic properties from tiled including physics
+- [x] Adds basic properties from Tiled including physics
 - [x] Supports object layers and tile layers
 - [x] Supports collections of images and tileset images
-- [x] Supports object x/y flipping and re-centering of anchorX/anchorY for Corona
+- [x] Supports object x/y flipping and re-centering of anchorX/anchorY for Solar2D
 - [x] Particle plugin
 - [x] Rectangle shape with fillColor and strokeColor support
 - [x] Polygon import with physics support for edge chains
@@ -28,7 +28,7 @@ map = tiled.new( data, dir )
 
 #### data
 
-Data is a lua table that contains an export of the tiled map in either .lua or .json format. The easiest way to populate that table is to export a map from Tiled in .lua format and *require* it in your code.
+Data is a lua table that contains an export of the Tiled map in either .lua or .json format. The easiest way to populate that table is to export a map from Tiled in .lua format and *require* it in your code.
 
 ![Lua export via Tiled](http://imgur.com/NJZuTM8.png)
 
@@ -57,7 +57,7 @@ map.xScale = 2
 map.alpha = 0.5
 map:translate(-30,30)
 ```
-map.designedWidth and map.designedHeight are the width and height of you map as specified in tiled's new map options. map objects also have functions to make it easy to find image objects to manipulate them with code.
+map.designedWidth and map.designedHeight are the width and height of you map as specified in Tiled's new map options. map objects also have functions to make it easy to find image objects to manipulate them with code.
 
 #### map:findObject(name)
 This funtion will return the *first* display object with the name specified. Great for getting to the display object of a unique item in the map.
@@ -93,7 +93,7 @@ The *extend()* function attaches a lua code module to a *image object*. You can 
 
 ### Custom Properties
 
-The most exciting part of working in Tiled & Corona is the idea of custom properites. You can select any *image object* on any *object layer* in tiled and add any number of custom properties. **ponytiled** will apply those properties to the image object as it loads. This allows you to put physics properties, custom draw modes, user data, etc. on an in-game item via the editor.
+The most exciting part of working in Tiled & Solar2D is the idea of custom properites. You can select any *image object* or *tile object* on any *object layer* or *tile layer* in Tiled and add any number of custom properties. **ponytiled** will apply those properties to the image object as it loads. This allows you to put physics properties, custom draw modes, user data, etc. on an in-game item via the editor.
 
 ![Setting a bodyType object](http://imgur.com/u3Ee6dD.png)
 

--- a/com/ponywolf/ponytiled.lua
+++ b/com/ponywolf/ponytiled.lua
@@ -175,7 +175,8 @@ function M.new(data, dir)
   function map.getFirstTile( property, value )
     for i = 1, #_levelTiles do
       local key = _levelTiles[i][property]
-      if key and key == value then
+      -- If the value isn't specified, then just return the first tile with the given property.
+      if key and (value == nil or value == key) then
         return _levelTiles[i]
       end
     end
@@ -185,7 +186,7 @@ function M.new(data, dir)
     local t = {}
     for i = 1, #_levelTiles do
       local key = _levelTiles[i][property]
-      if key and key == value then
+      if key and (value == nil or value == key) then
         t[#t+1] = _levelTiles[i]
       end
     end


### PR DESCRIPTION
By default, ponytiled seems to only support adding physics bodies and copying properties from Tiled to object layer items. This addition extends the functionality to tile layer items as well and adds two functions to return all tiles or the first tile with a given property and value via `map.getAllTiles( property, value )` and `map.getFirstTile( property, value )`.

Also making minor fixes to the README and adding a reference of these tile object/layer changes.