### PR TITLE
Fixes, improvements, and new features for ponytiled.lua and xml.lua

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Ponywolf
+Copyright (c) 2016-2025 Ponywolf
+Copyright (c) 2022-2026 Eetu Rantanen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ for i = 1, #enemies do
   print( "enemy #" .. i .. " = " .. tostring( enemies[i] ) )
 end
 ```
+#### map:getLayerGrid( name )
+Returns a tile layer's data as a 2D table (`grid[row][col]`) containing raw GID values. Useful when a tile layer is used as a data grid for collisions, walkable areas, pathfinding, or similar logic rather than just visuals. For example, a "collision" layer where tile 1 means blocked and 0 means open.
+```
+local grid = map:getLayerGrid( "collision" )
+for row = 1, #grid do
+  for col = 1, #grid[row] do
+    if grid[row][col] > 0 then
+      print( "Blocked at row " .. row .. ", col " .. col )
+    end
+  end
+end
+```
 #### map:showLayer(name)
 Set a layer to visible
 #### map:hideLayer(name)

--- a/README.md
+++ b/README.md
@@ -3,21 +3,21 @@
 
 ![Screenshot of ponytiled in action](http://i.imgur.com/HJQJTiw.png)
 
-In about 675 lines of code, **ponytiled** loads a sub-set of Tiled layers, tilesets and image collections. Built in plugin hooks and extensions make it easy to add support for many custom object types.
+In less than 900 lines of code, **ponytiled** loads a sub-set of Tiled layers, tilesets and image collections. Built in plugin hooks and extensions make it easy to add support for many custom object types.
 
 - [x] Loads .LUA + .JSON exports from www.mapeditor.org
 - [x] Adds basic properties from Tiled including physics
-- [x] Supports object layers and tile layers
+- [x] Supports object layers, tile layers and group layers
 - [x] Supports collections of images and tileset images
 - [x] Supports object x/y flipping and re-centering of anchorX/anchorY for Solar2D
 - [x] Particle plugin
 - [x] Rectangle shape with fillColor and strokeColor support
 - [x] Polygon import with physics support for edge chains
-- [x] Support for tilesheet based external tilesets (TSX files)
-- [x] Basic support for collection of images external tilesets (TSX files)
+- [x] Support for external tilesets (TSX files), both tilesheets and image collections
 - [x] Basic UI plugins for dragables, buttons and labels
 - [x] Particle plugin support for JSON particles http://particle2dx.com/
-- [x] Basic animated tiles
+- [x] Animated tiles
+- [x] TTF text objects
 
 ### Quick Start Guide
 
@@ -39,7 +39,7 @@ local map = tiled.new(mapData)
 
 #### dir
 
-Most of the time you will store you maps and images/tilesets in a directory. The dir parameter overides where **ponytiled** looks for images.
+Most of the time you will store you maps and images/tilesets in a directory. The dir parameter overrides where **ponytiled** looks for images.
 
 ```
 local mapData = require "maps.objects.sandbox" -- load from lua export
@@ -60,7 +60,7 @@ map:translate(-30,30)
 map.designedWidth and map.designedHeight are the width and height of you map as specified in Tiled's new map options. map objects also have functions to make it easy to find image objects to manipulate them with code.
 
 #### map:findObject(name)
-This funtion will return the *first* display object with the name specified. Great for getting to the display object of a unique item in the map.
+This function will return the *first* display object with the name specified. Great for getting to the display object of a unique item in the map.
 
 ![Setting a hero name](http://imgur.com/qLJayzG.png)
 
@@ -85,7 +85,7 @@ myLayer = map:findLayer( "hud" )
 myLayer.alpha = 0.5
 ```
 #### map:getFirstTile( property [, value ] )
-This funtion will return the *first* tile-based display object with the specified property in the map. Great for getting to the display object of a unique tile in the map. Optionally, you can specify a value for the property. If the value is omitted, the function will return the first tile that has the specified property regardless of the value of the property.
+This function will return the *first* tile-based display object with the specified property in the map. Great for getting to the display object of a unique tile in the map. Optionally, you can specify a value for the property. If the value is omitted, the function will return the first tile that has the specified property regardless of the value of the property.
 ```
 finishTile = map:getFirstTile( "type", "finish" )
 transition.blink( finishTile, { time=1000 } )
@@ -115,7 +115,7 @@ The *extend()* function attaches a lua code module to a *image object*. You can 
 
 ### Custom Properties
 
-The most exciting part of working in Tiled & Solar2D is the idea of custom properites. You can select any *image object* or *tile object* on any *object layer* or *tile layer* in Tiled and add any number of custom properties. **ponytiled** will apply those properties to the image object as it loads. This allows you to put physics properties, custom draw modes, user data, etc. on an in-game item via the editor.
+The most exciting part of working in Tiled & Solar2D is the idea of custom properties. You can select any *image object* or *tile object* on any *object layer* or *tile layer* in Tiled and add any number of custom properties. **ponytiled** will apply those properties to the image object as it loads. This allows you to put physics properties, custom draw modes, user data, etc. on an in-game item via the editor.
 
 ![Setting a bodyType object](http://imgur.com/u3Ee6dD.png)
 
@@ -125,7 +125,6 @@ One special custom property is *bodyType*. This triggers **ponytiled** to add a 
 
 ### Watchouts
 
-* Only the most basic support for TSX files (also known as external tilesets)
 * Ellipse types are rendered as circles
 * Only supports XML or CSV layer data types (see below)
 

--- a/com/coronalabs/xml.lua
+++ b/com/coronalabs/xml.lua
@@ -1,21 +1,27 @@
---module(..., package.seeall)
-
 ---------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------
 --
--- xml.lua - XML parser for use with the Corona SDK.
+-- xml.lua - XML parser for use with Solar2D (formerly Corona SDK).
 --
--- version: 1.0
+-- version: 1.0.1
 --
 -- NOTE: This is a modified version of Alexander Makeev's Lua-only XML parser
 -- found here: http://lua-users.org/wiki/LuaXml
 --
 ---------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------
-local M={}
+
+local M = {}
+
 function M.newParser()
 
 	local DEBUG = false
+
+	local function log(...)
+		if DEBUG then
+			print("XmlParser: ", ... )
+		end
+	end
 
 	local XmlParser = {}
 
@@ -27,24 +33,25 @@ function M.newParser()
 		value = string.gsub (value, "\"", "&quot;")  -- '"' -> "&quot;"
 		-- replace non printable char -> "&#xD;"
 		value = string.gsub(value, "([^%w%&%;%p%\t% ])",
-			function (c) 
-				return string.format("&#x%X;", string.byte(c)) 
-				--return string.format("&#x%02X;", string.byte(c)) 
-				--return string.format("&#%02d;", string.byte(c)) 
-			end);
+			function (c)
+				return string.format("&#x%X;", string.byte(c))
+				--return string.format("&#x%02X;", string.byte(c))
+				--return string.format("&#%02d;", string.byte(c))
+			end)
+
 		return value
 	end
 
-	function XmlParser:FromXmlString(value)  
+	function XmlParser:FromXmlString(value)
 		value = string.gsub(value, "&#x([%x]+)%;",
-			function(h) 
-				return string.char(tonumber(h,16)) 
+			function(h)
+				return string.char(tonumber(h,16))
 			end)
 		value = string.gsub(value, "&#([0-9]+)%;",
 			function(h)
 				--
 				-- hack to deal with UTF-8 entities
-				-- 
+				--
 				if h == "8217" or h == "8216" or h == "8218" then return "'" end
 				if h == "8211" then return "-" end
 				if h == "8212" then return "--" end
@@ -53,14 +60,15 @@ function M.newParser()
 				if h == "8214" then return "(tm)" end
 				if h == "8226" then return "." end
 				if tonumber(h) >= 1000 then return "" end
-				return string.char(tonumber(h,10)) 
-			end);
+				return string.char(tonumber(h,10))
+			end)
 		value = string.gsub (value, "&quot;", "\"")
 		value = string.gsub (value, "&apos;", "'")
 		value = string.gsub (value, "&gt;", ">")
 		value = string.gsub (value, "&lt;", "<")
 		value = string.gsub (value, "&amp;", "&")
-		return value;
+
+		return value
 	end
 
 	function XmlParser:ParseArgs(s)
@@ -68,51 +76,50 @@ function M.newParser()
 		string.gsub(s, "(%w+)=([\"'])(.-)%2", function (w, _, a)
 				arg[w] = self:FromXmlString(a)
 			end)
+
 		return arg
 	end
 
-	function log(...)
-		if DEBUG then
-			print("XmlParser: ", unpack(arg))
-		end
-	end
-
-	function XmlParser:ParseXmlText(xmlText)    
+	function XmlParser:ParseXmlText(xmlText)
 		local stack = {}
 		local top = {name=nil,value=nil,properties={},child={}}
 		table.insert(stack, top)
 		local ni,c,label,xarg, empty,cdata_end,cdata_end2,abs
 		local i, j = 1, 1
-		while true do      
-			ni, j, c, label, xarg, empty = 
-			xmlText:find("<(%/?)([%w:]+)(.-)(%/?)>", i)                        
-			if not ni then break end    
 
-			local text = string.sub(xmlText, i, ni-1)         
+		while true do
+			ni, j, c, label, xarg, empty =
+			xmlText:find("<(%/?)([%w:]+)(.-)(%/?)>", i)
+			if not ni then break end
 
-			local cdata_start,cdata_start2 = text:find("<!%[CDATA%[")        
-			if (cdata_start) then
-				abs = i+cdata_start2       
-				log("Found CDATA start tag", abs)        
+			local text = string.sub(xmlText, i, ni-1)
+
+			local cdata_start,cdata_start2 = text:find("<!%[CDATA%[")
+			if cdata_start then
+				abs = i+cdata_start2
+				log("Found CDATA start tag", abs)
 				cdata_end, cdata_end2 = xmlText:find("%]%]>",i)
-				log("Found CDATA end tag", cdata_end2)      
+				log("Found CDATA end tag", cdata_end2)
 				i = cdata_end2+1
-			else 
+			else
 				i = j+1
 			end
 
-			if not cdata_start and not string.find(text, "^%s*$") then -- skip white space           
-				top.value=(top.value or "")..self:FromXmlString(text)      
+			if not cdata_start and not string.find(text, "^%s*$") then -- skip white space
+				top.value=(top.value or "")..self:FromXmlString(text)
 			end
 
-			if cdata_start then -- CDATA 
+			if cdata_start then -- CDATA
 				top.value = (top.value or "")..xmlText:sub(abs,cdata_end-1)
+
 			elseif empty == "/" then  -- empty element tag
 				table.insert(top.child, {name=label,value=nil,properties=self:ParseArgs(xarg),child={}})
+
 			elseif c == "" then   -- start tag
 				top = {name=label, value=nil, properties=self:ParseArgs(xarg), child={}}
 				table.insert(stack, top)   -- new level
 				log("openTag ="..top.name)
+
 			else  -- end tag
 				local toclose = table.remove(stack)  -- remove top
 				log("closeTag="..toclose.name)
@@ -120,20 +127,23 @@ function M.newParser()
 				if #stack < 1 then
 					error("XmlParser: nothing to close with "..label)
 				end
-				if toclose.name ~= label then        
+
+				if toclose.name ~= label then
 					error("XmlParser: trying to close <"..toclose.name.."> with <"..label..">")
 				end
-				table.insert(top.child, toclose)
-			end  
 
+				table.insert(top.child, toclose)
+			end
 		end
+
 		local text = string.sub(xmlText, i)
 		if not string.find(text, "^%s*$") then
 			stack[#stack].value=(stack[#stack].value or "")..self:FromXmlString(text)
 		end
+
 		if #stack > 1 then
-			error("XmlParser: unclosed "..stack[stack.n].name)
-		end  
+			error("XmlParser: unclosed "..stack[#stack].name)
+		end
 
 		--local xml_obj = XmlObject(stack[1].child[1])
 
@@ -147,15 +157,18 @@ function M.newParser()
 		end
 
 		local path = system.pathForFile( xmlFilename, base )
-		local hFile, err = io.open(path,"r")
+		if not path then
+			error( "ERROR: xml:loadFile() - file not found: " .. tostring( xmlFilename ) )
+		end
 
-		if hFile and not err then
+		local hFile, errorMessage = io.open(path,"r")
+
+		if hFile and not errorMessage then
 			local xmlText=hFile:read("*a") -- read file content
 			io.close(hFile)
-			return self:ParseXmlText(xmlText),nil
+			return self:ParseXmlText(xmlText)
 		else
-			print( err )
-			return nil
+			error( errorMessage )
 		end
 	end
 

--- a/com/ponywolf/ponytiled.lua
+++ b/com/ponywolf/ponytiled.lua
@@ -4,9 +4,7 @@
 
 local physics = require "physics"
 local xml = require("com.coronalabs.xml").newParser()
---local path = require "com.luapower.path" --optional to resolve relative paths on android
 --local translate = require "com.ponywolf.translator"
---local json = require "json"
 
 local M = {}
 local defaultExtensions = "com.ponywolf.plugins."
@@ -15,20 +13,31 @@ local FlippedHorizontallyFlag   = 0x80000000
 local FlippedVerticallyFlag     = 0x40000000
 local FlippedDiagonallyFlag     = 0x20000000
 
+local function normalizePath( p )
+  local parts = {}
+  for part in p:gmatch( "[^/\\]+" ) do
+    if part == ".." then
+      if #parts > 0 then
+        parts[#parts] = nil
+      end
+    elseif part ~= "." then
+      parts[#parts + 1] = part
+    end
+  end
+  return table.concat( parts, "/" )
+end
+
 local function hasbit(x, p) return x % (p + p) >= p end
-local function setbit(x, p) return hasbit(x, p) and x or x + p end
 local function clearbit(x, p) return hasbit(x, p) and x - p or x end
 
 local function tiledProperties(properties)
-  if (#properties > 0) and properties[1].name and properties[1].value then
+  if (#properties > 0) and properties[1].name and properties[1].value ~= nil then
     --new tiled style
     local t = {}
     for i = 1, #properties do
       if translate then
         if properties[i].type == "string" and (properties[i].name == "text" or properties[i].name == "title") and (not tonumber(properties[i].value)) then
-          if translate then
-            properties[i].value = translate(properties[i].value)
-          end
+          properties[i].value = translate(properties[i].value)
         end
       end
       if properties[i].value ~= "" then t[properties[i].name] = properties[i].value end
@@ -67,8 +76,8 @@ local function decodeTiledColor(hex)
   local function hexToFloat(part)
     return tonumber("0x".. part or "00") / 255
   end
-  local a, r, g, b =  hexToFloat(hex:sub(1,2)), hexToFloat(hex:sub(3,4)), hexToFloat(hex:sub(5,6)) , hexToFloat(hex:sub(7,8))
-  return r,g,b,a
+  local a, r, g, b =  hexToFloat(hex:sub(1,2)), hexToFloat(hex:sub(3,4)), hexToFloat(hex:sub(5,6)), hexToFloat(hex:sub(7,8))
+  return r, g, b, a
 end
 
 local function unpackPoints(points, dx, dy)
@@ -86,10 +95,103 @@ function M.new(data, dir)
   local map = display.newGroup()
   dir = dir and (dir .. "/") or "" -- where does the map live?
 
-  local layers = data.layers
+  -- Flatten group layers so nested tile/object layers are processed.
+  -- Group visibility, opacity, and offsets are propagated to children.
+  local function flattenLayers( source, parentVisible, parentOpacity, parentOffsetX, parentOffsetY )
+    parentVisible = (parentVisible == nil) and true or parentVisible
+    parentOpacity = parentOpacity or 1
+    parentOffsetX = parentOffsetX or 0
+    parentOffsetY = parentOffsetY or 0
+    local result = {}
+    for i = 1, #source do
+      local layer = source[i]
+      if layer.type == "group" and layer.layers then
+        local nested = flattenLayers(
+          layer.layers,
+          parentVisible and (layer.visible ~= false),
+          parentOpacity * (layer.opacity or 1),
+          parentOffsetX + (layer.offsetx or 0),
+          parentOffsetY + (layer.offsety or 0)
+        )
+        for j = 1, #nested do
+          result[#result + 1] = nested[j]
+        end
+      else
+        layer.visible = parentVisible and (layer.visible ~= false)
+        layer.opacity = parentOpacity * (layer.opacity or 1)
+        layer.offsetx = parentOffsetX + (layer.offsetx or 0)
+        layer.offsety = parentOffsetY + (layer.offsety or 0)
+        result[#result + 1] = layer
+      end
+    end
+    return result
+  end
+
+  local layers = flattenLayers( data.layers )
   local tilesets = data.tilesets
   local width, height = data.width * data.tilewidth, data.height * data.tileheight
   local sheets = {}
+
+  -- Check each tileset for its tiles definition table and copy
+  -- every tile's properties to their own table for later lookup.
+  local _tileData = {}
+
+  for i = 1, #tilesets do
+    if type( tilesets[i].tiles ) == "table" then
+      local firstgid = tilesets[i].firstgid
+
+      for _, t in pairs( tilesets[i].tiles ) do
+        local n = t.id+firstgid
+        _tileData[n] = {}
+
+        if t.properties then
+          for j = 1, #t.properties do
+            local t = t.properties[j]
+            _tileData[n][t.name] = t.value
+          end
+        end
+      end
+    end
+  end
+
+  -- List of tiles in the current map.
+  local _levelTiles = {}
+
+  -- Reserved tile property names for physics bodies.
+  local physicsProperties = {
+    density = true,
+    friction = true,
+    bounce = true,
+    bodyType = true,
+    radius = true,
+    shape = true,
+    box = true,
+    chain = true,
+    connectFirstAndLastChainVertex  = true,
+    outline = true,
+    isSensor = true,
+  }
+
+  -- Check if a tile has the given property and return the first tile with a matching value.
+  function map:getFirstTile( property, value )
+    for i = 1, #_levelTiles do
+      local key = _levelTiles[i][property]
+      if key and (value == nil or value == key) then
+        return _levelTiles[i]
+      end
+    end
+  end
+
+  function map:getAllTiles( property, value )
+    local t = {}
+    for i = 1, #_levelTiles do
+      local key = _levelTiles[i][property]
+      if key and (value == nil or value == key) then
+        t[#t+1] = _levelTiles[i]
+      end
+    end
+    return t
+  end
 
   local function loadTileset(num)
     local tileset = tilesets[num]
@@ -119,8 +221,8 @@ function M.new(data, dir)
         frames[#frames + 1] = element
       end
     end
-    --print("LOADED:", dir .. tileset.image)
-    return graphics.newImageSheet(dir .. tileset.image, options )
+    local filename = normalizePath( dir .. tileset.image )
+    return graphics.newImageSheet( filename, options )
   end
 
   local function findLast(tileset)
@@ -152,17 +254,49 @@ function M.new(data, dir)
       local tileset = tilesets[i]
       local firstgid = tileset.firstgid
       if tileset.source then
-        print ("WARNING: External tilesets only suported for tilesheets...")
-        local externalSet = xml:loadFile(dir .. tileset.source)
-        tileset.image = externalSet.child[1].properties.source
-        tileset.width = externalSet.child[1].properties.width
-        tileset.height = externalSet.child[1].properties.height
+        -- Resolve image paths relative to the TSX file's directory, not the map's.
+        local tsxDir = tileset.source:match( "(.*/)") or ""
+        local externalSet = xml:loadFile( dir .. tileset.source )
         tileset.tileheight = externalSet.properties.tileheight
         tileset.tilewidth = externalSet.properties.tilewidth
         tileset.columns = externalSet.properties.columns
         tileset.name = externalSet.properties.name
         tileset.tilecount = externalSet.properties.tilecount
-        tileset.source = nil -- no longer load the XML
+
+        -- Find the top-level <image> child (tilesheets have one, collections don't).
+        local imageChild
+        for c = 1, #externalSet.child do
+          if externalSet.child[c].name == "image" then
+            imageChild = externalSet.child[c]
+            break
+          end
+        end
+
+        if imageChild then
+          -- Tilesheet: single shared image.
+          tileset.image = tsxDir .. imageChild.properties.source
+          tileset.imagewidth = imageChild.properties.width
+          tileset.imageheight = imageChild.properties.height
+        else
+          -- Collection of images: each <tile> has its own <image>.
+          tileset.tiles = {}
+          for c = 1, #externalSet.child do
+            local child = externalSet.child[c]
+            if child.name == "tile" then
+              local tileEntry = { id = tonumber( child.properties.id ) }
+              for ic = 1, #child.child do
+                if child.child[ic].name == "image" then
+                  tileEntry.image = tsxDir .. child.child[ic].properties.source
+                  tileEntry.imagewidth = tonumber( child.child[ic].properties.width )
+                  tileEntry.imageheight = tonumber( child.child[ic].properties.height )
+                  break
+                end
+              end
+              tileset.tiles[#tileset.tiles + 1] = tileEntry
+            end
+          end
+        end
+        tileset.source = nil
       end
       local lastgid = findLast(tileset)
 
@@ -175,14 +309,14 @@ function M.new(data, dir)
           if tileset.tiles then
             for t = 1, #tileset.tiles do
               local tile = tileset.tiles[t]
+              tile.properties = tiledProperties(tile.properties or {})
               if tile.animation and tile.id == (gid - firstgid + (data.luaversion and 1 or 0)) then
-                tile = inherit(tile, tiledProperties(tile.properties or {}))
                 sequenceData = {
                   name="imported",
-                  frames= { },
+                  frames= {},
                   time = 0,
-                  loopCount = tile.loopCount or 0,
-                  loopDirection = tile.loopDirection,
+                  loopCount = tile.properties.loopCount or 0,
+                  loopDirection = tile.properties.loopDirection,
                 }
                 for frame=1, #tile.animation do
                   table.insert(sequenceData.frames, tile.animation[frame].tileid + 1)
@@ -215,7 +349,7 @@ function M.new(data, dir)
 
   for i = 1, #layers do
     local layer = layers[i]
-    layer.properties = layer.properties or {} -- make sure we have a properties table
+    layer.properties = tiledProperties(layer.properties or {}) -- make sure we have a properties table
     local objectGroup = display.newGroup()
     if layer.type == "tilelayer" then
       if layer.compression or layer.encoding then
@@ -231,24 +365,50 @@ function M.new(data, dir)
             local image
             if animation then
               --print("Animating:", gid)
-              image = display.newSprite(objectGroup, sheet, animation )
+              image = display.newSprite(objectGroup, sheet, animation)
               image:play("imported")
             else
-              image = sheet and display.newImage(objectGroup, sheet, gid, 0, 0) or display.newImage(objectGroup, dir .. gid, 0, 0)
+              image = sheet and display.newImage(objectGroup, sheet, gid, 0, 0) or display.newImage(objectGroup, normalizePath( dir .. gid ), 0, 0)
             end
             image.anchorX, image.anchorY = 0,1
             image.gid = tileNumber
             image.x, image.y = tx * data.tilewidth, (ty+1) * data.tileheight
             centerAnchor(image)
-            -- flip it
-            if flip.xy then
-              print("WARNING: Unsupported Tiled mirror x,y in tile ", tx,ty)
-            else
-              if flip.x then image.xScale = -1 end
-              if flip.y then image.yScale = -1 end
+
+            -- Assign any properties set in Tiled to the actual tile object.
+            local strippedGid = clearbit(clearbit(clearbit(tileNumber, FlippedHorizontallyFlag), FlippedVerticallyFlag), FlippedDiagonallyFlag)
+            local data = _tileData[strippedGid]
+            if type( data ) == "table" then
+              local physicsData = {}
+
+              -- Separate physics properties from everything else.
+              for k, v in pairs( data ) do
+                if physicsProperties[k] then
+                  physicsData[k] = v
+                else
+                  image[k] = v
+                end
+              end
+              -- number of the tile in its image sheet.
+              image.tileNum = gid
+
+              if physicsData.bodyType then
+                physics.addBody( image, physicsData.bodyType, physicsData )
+              end
             end
+
+            -- Add the tile to a table for later access.
+            _levelTiles[#_levelTiles+1] = image
+
             -- apply custom properties
             image = inherit(image, layer.properties)
+            -- flip it
+            if flip.xy then
+              print("WARNING: Unsupported Tiled mirror x, y in tile ", tx,ty)
+            else
+              if flip.x then image.xScale = -1 * image.xScale end
+              if flip.y then image.yScale = -1 * image.yScale end
+            end
           end
         end
       end
@@ -263,11 +423,13 @@ function M.new(data, dir)
             local image
             if animation then
               --print("Animating:", gid)
-              image = display.newSprite(objectGroup, sheet, animation )
+              image = display.newSprite(objectGroup, sheet, animation)
               image:play("imported")
+              image.xScale = object.width / image.width
+              image.yScale = object.height / image.height
             else
               image = sheet and display.newImageRect(objectGroup, sheet, gid, object.width, object.height) or
-              display.newImageRect(objectGroup, path and path.normalize(dir .. gid) or (dir .. gid), object.width, object.height)
+              display.newImageRect(objectGroup, normalizePath( dir .. gid ), object.width, object.height)
             end
             -- missing
             if not image then -- placeholder
@@ -277,8 +439,8 @@ function M.new(data, dir)
             -- name and type
             image.name = object.name
             image.type = object.type
-            image.filename = sheet and "none" or (dir .. gid)
             image.id = object.id
+            image.filename = sheet and "none" or normalizePath( dir .. gid )
             -- apply base properties
             local anchorX, anchorY = object.properties.anchorX, object.properties.anchorY
             object.properties.anchorX, object.properties.anchorY = nil, nil
@@ -291,18 +453,18 @@ function M.new(data, dir)
             if image.fillColor then image:setFillColor(decodeTiledColor(image.fillColor)) end
             -- flip it
             if flip.xy then
-              print("WARNING: Unsupported Tiled rotation x,y in ", object.name)
+              print("WARNING: Unsupported Tiled rotation x, y in ", object.name)
             else
-              if flip.x then image.xScale = -1 end
-              if flip.y then image.yScale = -1 end
+              if flip.x then image.xScale = -1 * image.xScale end
+              if flip.y then image.yScale = -1 * image.yScale end
             end
             -- autotrace shape
             local autoShape = object.properties.autoShape
             if autoShape then
               if not sheet then
-                object.properties.outline = graphics.newOutline( autoShape, path and path.normalize(dir .. gid) or (dir .. gid))
+                object.properties.outline = graphics.newOutline( autoShape, normalizePath( dir .. gid ) )
               else
-                object.properties.outline = graphics.newOutline( autoShape, sheet, gid)
+                object.properties.outline = graphics.newOutline(autoShape, sheet, gid)
               end
             end
             -- not so simple physics
@@ -315,7 +477,7 @@ function M.new(data, dir)
                   y = object.properties.boxY or 0,
                   angle= object.properties.boxAngle or 0 }
               end
-              physics.addBody(image, object.properties.bodyType, object.properties)
+              physics.addBody(image, object.properties.bodyType or layer.properties.bodyType, object.properties)
             end
             -- apply custom properties
             image = inherit(image, layer.properties)
@@ -336,7 +498,7 @@ function M.new(data, dir)
             polygon = display.newPolygon(objectGroup, object.x, object.y, unpackPoints(points))
             polygon:translate(originX, originY)
           else
-            polygon = display.newLine( objectGroup, points[1].x, points[1].y, points[2].x, points[2].y)
+            polygon = display.newLine(objectGroup, points[1].x, points[1].y, points[2].x, points[2].y)
             originX, originY = points[1].x, points[1].y
             for p = 3, #points do
               polygon:append(points[p].x, points[p].y)
@@ -344,19 +506,17 @@ function M.new(data, dir)
             polygon.x,polygon.y = object.x, object.y
             polygon:translate(originX, originY)
           end
+          polygon.points = points
           -- simple physics
           if object.properties.bodyType then
-            if true then -- always make chains
-              object.properties.chain = unpackPoints(points, -originX, -originY)
-              object.properties.connectFirstAndLastChainVertex = object.polygon and true or false
-            else
-              object.properties.shape = unpackPoints(points, -originX, -originY)
-            end
+            object.properties.chain = unpackPoints(points, -originX, -originY)
+            object.properties.connectFirstAndLastChainVertex = object.polygon and true or false
             physics.addBody(polygon, object.properties.bodyType, object.properties)
           end
           -- name and type
           polygon.name = object.name
           polygon.type = object.type
+          polygon.id = object.id
           -- apply custom properties
           polygon = inherit(polygon, layer.properties)
           polygon = inherit(polygon, object.properties)
@@ -378,6 +538,7 @@ function M.new(data, dir)
           -- name and type
           circle.name = object.name
           circle.type = object.type
+          circle.id = object.id
           -- apply custom properties
           circle = inherit(circle, layer.properties)
           circle = inherit(circle, object.properties)
@@ -386,11 +547,10 @@ function M.new(data, dir)
           if circle.strokeColor then circle:setStrokeColor(decodeTiledColor(circle.strokeColor)) end
         elseif object.text then
           -- TTF font loading
-          local font = object.TTF
+          local font = object.properties.TTF
           local size = object.text.pixelsize
           local color = object.text.color
           local text = display.newText(objectGroup, object.text.text or " ", object.x, object.y, font or native.systemFont, size)
-          print ("color", color)
           text:setFillColor(decodeTiledColor(color or "FFFFFF"))
           text.anchorX, text.anchorY = 0.0, 0.0
           text.rotation = object.rotation
@@ -417,6 +577,7 @@ function M.new(data, dir)
           -- name and type
           rect.name = object.name
           rect.type = object.type
+          rect.id = object.id
           -- apply custom properties
           rect = inherit(rect, layer.properties)
           rect = inherit(rect, object.properties)
@@ -554,7 +715,7 @@ function M.new(data, dir)
         map[layer][object]:translate(-width/2, -height/2)
       end
     end
-    map.anchorX, map.anchorX = 0.5, 0.5
+    map.anchorX, map.anchorY = 0.5, 0.5
   end
 
 -- Make sure map stays on screen
@@ -577,19 +738,19 @@ function M.new(data, dir)
   end
 
   local function rightToLeft(a,b)
-    return (a.x or 0) + (a.width or 0) * 0.5 > (b.x or 0) + (b.width or 0) * 0.5
+    return (a.x or 0) + (a.contentWidth or 0) * 0.5 > (b.x or 0) + (b.contentWidth or 0) * 0.5
   end
 
   local function leftToRight(a,b)
-    return (a.x or 0) + (a.width or 0) * 0.5 < (b.x or 0) + (b.width or 0) * 0.5
+    return (a.x or 0) + (a.contentWidth or 0) * 0.5 < (b.x or 0) + (b.contentWidth or 0) * 0.5
   end
 
   local function upToDown(a,b)
-    return (a.y or 0) + (a.height or 0) * ((1 - a.anchorY) or 0.5) < (b.y or 0) + (b.height or 0) * ((1 - b.anchorY)or 0.5)
+    return (a.y or 0) + (a.contentHeight or 0) * (1 - (a.anchorY or 0.5)) < (b.y or 0) + (b.contentHeight or 0) * (1 - (b.anchorY or 0.5))
   end
 
   local function downToUp(a,b)
-    return (a.y or 0) + (a.height or 0) * ((1 - a.anchorY) or 0.5) > (b.y or 0) + (b.height or 0) * ((1 - b.anchorY) or 0.5)
+    return (a.y or 0) + (a.contentHeight or 0) * (1 - (a.anchorY or 0.5)) > (b.y or 0) + (b.contentHeight or 0) * (1 - (b.anchorY or 0.5))
   end
 
   function map:sort(reverse)
@@ -613,7 +774,7 @@ function M.new(data, dir)
     end
   end
 
-  function map:sortLayer(layer,reverse)
+  function map:sortLayer(layer, reverse)
     local objects = {}
     local layerToSort = map:findLayer(layer) or {}
     if layerToSort.numChildren then

--- a/com/ponywolf/ponytiled.lua
+++ b/com/ponywolf/ponytiled.lua
@@ -156,6 +156,9 @@ function M.new(data, dir)
   -- List of tiles in the current map.
   local _levelTiles = {}
 
+  -- Raw tile data per layer, copied for getLayerGrid.
+  local _layerData = {}
+
   -- Reserved tile property names for physics bodies.
   local physicsProperties = {
     density = true,
@@ -190,6 +193,21 @@ function M.new(data, dir)
       end
     end
     return t
+  end
+
+  -- Return tile layer data as grid[row][col] of raw GIDs.
+  function map:getLayerGrid( name )
+    local entry = _layerData[name]
+    if not entry then return nil end
+    local grid = {}
+    local w = entry.width
+    for row = 1, entry.height do
+      grid[row] = {}
+      for col = 1, w do
+        grid[row][col] = entry.data[(row - 1) * w + col] or 0
+      end
+    end
+    return grid
   end
 
   local function loadTileset(num)
@@ -354,6 +372,11 @@ function M.new(data, dir)
       if layer.compression or layer.encoding then
         print ("ERROR: Tile layer encoding/compression not supported. Choose CSV or XML in map options.")
       end
+      -- Copy raw tile data for getLayerGrid.
+      local layerCopy = {}
+      for t = 1, #layer.data do layerCopy[t] = layer.data[t] end
+      _layerData[layer.name] = { data = layerCopy, width = data.width, height = data.height }
+
       local item = 0
       for ty=0, data.height-1 do
         for tx=0, data.width-1 do

--- a/com/ponywolf/ponytiled.lua
+++ b/com/ponywolf/ponytiled.lua
@@ -74,7 +74,7 @@ local function decodeTiledColor(hex)
     hex = "FF"..hex
   end
   local function hexToFloat(part)
-    return tonumber("0x".. part or "00") / 255
+    return tonumber("0x" .. (part or "00")) / 255
   end
   local a, r, g, b =  hexToFloat(hex:sub(1,2)), hexToFloat(hex:sub(3,4)), hexToFloat(hex:sub(5,6)), hexToFloat(hex:sub(7,8))
   return r, g, b, a
@@ -139,13 +139,13 @@ function M.new(data, dir)
     if type( tilesets[i].tiles ) == "table" then
       local firstgid = tilesets[i].firstgid
 
-      for _, t in pairs( tilesets[i].tiles ) do
-        local n = t.id+firstgid
+      for _, tile in pairs( tilesets[i].tiles ) do
+        local n = tile.id+firstgid
         _tileData[n] = {}
 
-        if t.properties then
-          for j = 1, #t.properties do
-            local t = t.properties[j]
+        if tile.properties then
+          for j = 1, #tile.properties do
+            local t = tile.properties[j]
             _tileData[n][t.name] = t.value
           end
         end
@@ -399,12 +399,12 @@ function M.new(data, dir)
 
             -- Assign any properties set in Tiled to the actual tile object.
             local strippedGid = clearbit(clearbit(clearbit(tileNumber, FlippedHorizontallyFlag), FlippedVerticallyFlag), FlippedDiagonallyFlag)
-            local data = _tileData[strippedGid]
-            if type( data ) == "table" then
+            local tileProps = _tileData[strippedGid]
+            if type( tileProps ) == "table" then
               local physicsData = {}
 
               -- Separate physics properties from everything else.
-              for k, v in pairs( data ) do
+              for k, v in pairs( tileProps ) do
                 if physicsProperties[k] then
                   physicsData[k] = v
                 else
@@ -733,11 +733,11 @@ function M.new(data, dir)
 
   function map:centerAnchor()
     for layer = 1, self.numChildren do
-      for object = 1, map[layer].numChildren do
-        map[layer][object]:translate(-width/2, -height/2)
+      for object = 1, self[layer].numChildren do
+        self[layer][object]:translate(-width/2, -height/2)
       end
     end
-    map.anchorX, map.anchorY = 0.5, 0.5
+    self.anchorX, self.anchorY = 0.5, 0.5
   end
 
   -- Make sure map stays on screen
@@ -798,7 +798,7 @@ function M.new(data, dir)
 
   function map:sortLayer(layer, reverse)
     local objects = {}
-    local layerToSort = map:findLayer(layer) or {}
+    local layerToSort = self:findLayer(layer) or {}
     if layerToSort.numChildren then
       for i = 1, layerToSort.numChildren do
         objects[#objects+1] = layerToSort[i]
@@ -873,8 +873,12 @@ function M.new(data, dir)
     if type(data.backgroundcolor) == "string" then
       display.setDefault("background", decodeTiledColor("FF" .. data.backgroundcolor))
     elseif type(data.backgroundcolor) == "table" then
-      for i = 1, #data.backgroundcolor do data.backgroundcolor[i] = data.backgroundcolor[i] / 255 end
-      display.setDefault("background", unpack(data.backgroundcolor))
+      -- Convert to 0-1 range without mutating the original data table.
+      local colors = {}
+      for i = 1, #data.backgroundcolor do
+        colors[i] = data.backgroundcolor[i] / 255
+      end
+      display.setDefault("background", unpack(colors))
     end
   end
 

--- a/com/ponywolf/ponytiled.lua
+++ b/com/ponywolf/ponytiled.lua
@@ -89,7 +89,6 @@ local function unpackPoints(points, dx, dy)
   return t
 end
 
-local centerX, centerY = display.contentCenterX, display.contentCenterY
 
 function M.new(data, dir)
   local map = display.newGroup()
@@ -701,7 +700,7 @@ function M.new(data, dir)
     -- find the difference between the hero and the display center
     -- and move the world to compensate
     local objx, objy = obj:localToContent(0,0)
-    objx, objy = centerX - objx , centerY - objy
+    objx, objy = display.contentCenterX - objx, display.contentCenterY - objy
     if tween then
       self.x, self.y = self.x + objx/4, self.y + objy/4
     else

--- a/com/ponywolf/ponytiled.lua
+++ b/com/ponywolf/ponytiled.lua
@@ -546,7 +546,7 @@ function M.new(data, dir)
           if circle.strokeColor then circle:setStrokeColor(decodeTiledColor(circle.strokeColor)) end
         elseif object.text then
           -- TTF font loading
-          local font = object.properties.TTF
+          local font = object.properties.TTF and normalizePath( dir .. object.properties.TTF )
           local size = object.text.pixelsize
           local color = object.text.color
           local text = display.newText(objectGroup, object.text.text or " ", object.x, object.y, font or native.systemFont, size)

--- a/com/ponywolf/ponytiled.lua
+++ b/com/ponywolf/ponytiled.lua
@@ -1,10 +1,10 @@
--- Project: PonyTiled is a simple Tiled Map Loader for Solar2D (formerly Corona SDK)
---
--- Loads TMJ saved map files from Tiled http://www.mapeditor.org/
+-- PonyTiled is a simple Tiled Map Loader for Solar2D (formerly Corona SDK)
 
-local physics = require "physics"
+-- Tiled: http://www.mapeditor.org/
+
+local physics = require("physics")
 local xml = require("com.coronalabs.xml").newParser()
---local translate = require "com.ponywolf.translator"
+--local translate = require("com.ponywolf.translator")
 
 local M = {}
 local defaultExtensions = "com.ponywolf.plugins."
@@ -32,7 +32,7 @@ local function clearbit(x, p) return hasbit(x, p) and x - p or x end
 
 local function tiledProperties(properties)
   if (#properties > 0) and properties[1].name and properties[1].value ~= nil then
-    --new tiled style
+    -- new tiled style
     local t = {}
     for i = 1, #properties do
       if translate then
@@ -486,7 +486,7 @@ function M.new(data, dir)
           local points = object.polygon or object.polyline
           local polygon, originX, originY
           if object.polygon then
-            local xMax, xMin, yMax, yMin = -4294967296, 4294967296, -4294967296, 4294967296 -- 32 ^ 2 a large number
+            local xMax, xMin, yMax, yMin = -4294967296, 4294967296, -4294967296, 4294967296 -- 2^32 (a large number)
             for p = 1, #points do
               if points[p].x < xMin then xMin = points[p].x end
               if points[p].y < yMin then yMin = points[p].y end
@@ -597,7 +597,7 @@ function M.new(data, dir)
     -- each custom object above has its own ponywolf.plugin module
     for t = 1, #extensions do
       -- load each module based on type
-      local plugin = require ((self.extensions or defaultExtensions) .. extensions[t])
+      local plugin = require((self.extensions or defaultExtensions) .. extensions[t])
       -- find each type of tiled object
       local images = self:listTypes(extensions[t])
       if images then
@@ -610,7 +610,7 @@ function M.new(data, dir)
     end
   end
 
--- return first display object with name
+  -- return first display object with name
   function map:findObject(name, type)
     if not self.numChildren then return false end
     for layers = self.numChildren,1,-1 do
@@ -632,7 +632,7 @@ function M.new(data, dir)
     return false
   end
 
--- return all display objects with names
+  -- return all display objects with names
   function map:findObjects(...)
     local objects = {}
     for layers = self.numChildren,1,-1 do
@@ -650,7 +650,7 @@ function M.new(data, dir)
     return objects
   end
 
--- return all display objects with type
+  -- return all display objects with type
   function map:listTypes(...)
     local objects = {}
     for layers = self.numChildren,1,-1 do
@@ -717,7 +717,7 @@ function M.new(data, dir)
     map.anchorX, map.anchorY = 0.5, 0.5
   end
 
--- Make sure map stays on screen
+  -- Make sure map stays on screen
   function map:boundsCheck(border)
     if self.translate then
       border = border or 0
@@ -839,13 +839,13 @@ function M.new(data, dir)
     end
   end
 
--- sort map by defaults
+  -- sort map by defaults
   map:sort()
 
--- add helpful values to the map itself
+  -- add helpful values to the map itself
   map.designedWidth, map.designedHeight = width, height
 
--- set the background color to the map background
+  -- set the background color to the map background
   if data.backgroundcolor then
     if type(data.backgroundcolor) == "string" then
       display.setDefault("background", decodeTiledColor("FF" .. data.backgroundcolor))


### PR DESCRIPTION
**ponytiled.lua** - New (and returning) features:

- Group layer support: `flattenLayers()` recursively processes group layers, propagating visibility, opacity, and offsets to children.
- `getLayerGrid(name)`: returns a 2D `grid[row][col]` table of raw GIDs for collision/logic lookups without traversing display objects. (*this was removed in a previous commit*)
- `getFirstTile(property, value)` and `getAllTiles(property, value)`: query placed tiles by property. (*this was removed in a previous commit*)
- Per-tile properties on tile layers: properties defined on individual tiles in Tiled (including physics bodies) are applied via a `_tileData` cache built during tileset init.
- Improved external tileset (TSX) support: fixes path resolution and adds support for image collections (multiple `<tile>` children with individual `<image>` sources), not just single-image tilesheets.
- `normalizePath()` utility: resolves `..` and `.` segments in all file paths passed to Solar2D image APIs.

**ponytiled.lua** - Bug fixes:

- Fixed operator precedence bug in `decodeTiledColor()` where `"0x" .. part or "00"` never hit the fallback and crashed on nil.
- Fixed `centerAnchor()` setting `anchorX` twice and never setting `anchorY`.
- Fixed `tiledProperties()` silently dropping properties with a `false` value.
- Fixed tile/object flip resetting scale to `-1` instead of multiplying existing scale.
- Fixed `backgroundcolor` normalization mutating input data in place, corrupting values on map reload.
- Fixed `display.contentCenterX/Y` cached at load time instead of read dynamically (broke on orientation change).
- Fixed `sortLayer()` closing over outer `map` variable instead of using `self`.
- Fixed sort helpers using `width`/`height` (local dims) instead of `contentWidth`/`contentHeight` (post-transform).
- Fixed missing `polygon.id` assignment for polygon/polyline objects.
- Fixed TTF font loading reading from raw data instead of normalized properties, and added path normalization.
- Fixed animation tile property reading mutating shared tileset data instead of using a local table.

**ponytiled.lua** - Cleanup:

- Removed stray debug print from text object block.
- Replaced optional `com.luapower.path` dependency with built-in `normalizePath()`.

**xml.lua** - Fixes and improvements:

- Updated SDK reference from "Corona SDK" to "Solar2D (formerly Corona SDK)" and bumped version to 1.0.1.
- Made the `log` function `local` (was a global leak in upstream).
- Fixed `log` to use `...` directly instead of `unpack(arg)`.
- Changed stack length access from `stack.n` to `#stack`.
- `loadFile` now validates the path and raises an `error()` on failure instead of silently printing and returning `nil`.
- General cleanup: removed trailing semicolons, trailing whitespace, and commented-out `module(..., package.seeall)` line.